### PR TITLE
style: fix padding and margin-bottom of recent tweets when both sideb…

### DIFF
--- a/src/app/studio/posted/page.tsx
+++ b/src/app/studio/posted/page.tsx
@@ -10,7 +10,7 @@ export default function PostedTweetsPage() {
   return (
     <div className="space-y-6 relative z-10 max-w-3xl mx-auto w-full">
       <div className="flex items-center gap-3">
-        <AccountAvatar className="size-10" />
+        <AccountAvatar className="size-10 mb-1" />
         <div className="flex flex-col">
           <h1 className="text-2xl font-semibold text-stone-900">Posted Tweets</h1>
           <p className="text-sm text-stone-600">

--- a/src/components/tweet-list.tsx
+++ b/src/components/tweet-list.tsx
@@ -241,7 +241,7 @@ export default function TweetList({
   }
 
   return (
-    <div className="relative z-10">
+    <div className="relative z-10 p-2">
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-bold text-stone-800">{title}</h1>


### PR DESCRIPTION
Fixes padding and margin-bottom of the recent tweets section when both left and right sidebars are open. This improves layout spacing and prevents the tweet list from appearing cramped.
Before:
<img width="1919" height="853" alt="Screenshot 2025-07-23 232233" src="https://github.com/user-attachments/assets/7ccb3974-f91e-4c4c-a2a4-b9509feb910f" />
After:
<img width="1915" height="860" alt="Screenshot 2025-07-23 232253" src="https://github.com/user-attachments/assets/3e489adc-e9d4-44df-8ac5-e62806da6ccd" />





