### PR TITLE
fix: clear post input field after adding to queue and  scheduling

### DIFF
--- a/src/components/tweet-editor/tweet.tsx
+++ b/src/components/tweet-editor/tweet.tsx
@@ -776,7 +776,14 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
       }))
 
     enqueueTweet({ content, media })
-
+    shadowEditor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        root.append($createParagraphNode())
+      },
+      { tag: 'force-sync' },
+    )
     // await scheduleTweetMutation.mutateAsync({
     //   content,
     //   scheduledUnix: nextSlot.scheduledUnix,
@@ -827,6 +834,15 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
         media,
       })
     }
+
+    shadowEditor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        root.append($createParagraphNode())
+      },
+      { tag: 'force-sync' },
+    )
   }
 
   const handlePostTweet = () => {


### PR DESCRIPTION
Previously, the post input field stayed filled even after the user added a post to the queue or scheduled it. This led to confusion, especially when navigating between views — the old text would still persist.

Now, the input field is automatically cleared after either action, resulting in a cleaner experience and avoiding accidental duplicate posts.
After:
https://github.com/user-attachments/assets/e0a939b2-020f-45ab-a601-d8ba1de2e5e8



Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The tweet editor now automatically clears and resets after adding a tweet to the queue or scheduling a tweet, ensuring it is ready for new input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->