### PR TITLE
fix pr 11 by clearing media files when scheduling/queueing tweet

### DIFF
--- a/src/components/tweet-editor/tweet.tsx
+++ b/src/components/tweet-editor/tweet.tsx
@@ -776,7 +776,14 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
       }))
 
     enqueueTweet({ content, media })
-
+    shadowEditor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        root.append($createParagraphNode())
+      },
+      { tag: 'force-sync' },
+    )
     // await scheduleTweetMutation.mutateAsync({
     //   content,
     //   scheduledUnix: nextSlot.scheduledUnix,
@@ -827,6 +834,15 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
         media,
       })
     }
+
+    shadowEditor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        root.append($createParagraphNode())
+      },
+      { tag: 'force-sync' },
+    )
   }
 
   const handlePostTweet = () => {

--- a/src/components/tweet-editor/tweet.tsx
+++ b/src/components/tweet-editor/tweet.tsx
@@ -500,6 +500,17 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
       })
 
       queryClient.invalidateQueries({ queryKey: ['scheduled-and-published-tweets'] })
+
+      shadowEditor.update(
+        () => {
+          const root = $getRoot()
+          root.clear()
+          root.append($createParagraphNode())
+        },
+        { tag: 'force-sync' }
+      )
+
+      setMediaFiles([])
     },
     onError: (error: HTTPException) => {
       if (error.status === 402) {
@@ -736,6 +747,17 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
         timeText = `${formattedTime} ${formattedDate}`
       }
 
+      setMediaFiles([])
+
+      shadowEditor.update(
+        () => {
+          const root = $getRoot()
+          root.clear()
+          root.append($createParagraphNode())
+        },
+        { tag: 'force-sync' }
+      )
+
       toast.success(
         <div className="flex gap-1.5 items-center">
           <p>Queued {isToday(scheduledDate) ? timeText : `for ${timeText}`}!</p>
@@ -776,20 +798,6 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
       }))
 
     enqueueTweet({ content, media })
-    shadowEditor.update(
-      () => {
-        const root = $getRoot()
-        root.clear()
-        root.append($createParagraphNode())
-      },
-      { tag: 'force-sync' },
-    )
-    // await scheduleTweetMutation.mutateAsync({
-    //   content,
-    //   scheduledUnix: nextSlot.scheduledUnix,
-    //   media,
-    //   showToast: false,
-    // })
   }
 
   const handleScheduleTweet = (date: Date, time: string) => {
@@ -834,15 +842,6 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
         media,
       })
     }
-
-    shadowEditor.update(
-      () => {
-        const root = $getRoot()
-        root.clear()
-        root.append($createParagraphNode())
-      },
-      { tag: 'force-sync' },
-    )
   }
 
   const handlePostTweet = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The tweet editor and attached media now automatically reset after successfully scheduling or queuing a tweet, ensuring a clean state for new posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->