### PR TITLE
fix: stop @ from deleting rest of tweet

### DIFF
--- a/src/lib/lexical-plugins/mention-plugin.tsx
+++ b/src/lib/lexical-plugins/mention-plugin.tsx
@@ -75,9 +75,16 @@ export default function MentionsPlugin() {
             const beforeCursor = text.slice(0, offset)
 
             if (beforeCursor.endsWith('@')) {
+              const afterCursor = text.slice(offset)
               anchorNode.setTextContent(beforeCursor.slice(0, -1))
               const mentionNode = new MentionNode2('@')
               anchorNode.insertAfter(mentionNode)
+              
+              if (afterCursor) {
+                const afterTextNode = $createTextNode(afterCursor)
+                mentionNode.insertAfter(afterTextNode)
+              }
+              
               selection.setTextNodeRange(mentionNode, 1, mentionNode, 1)
               return
             }


### PR DESCRIPTION
Previously there was a bug where if you wrote a post and insterted an @ to tag someone inside the text it would get rid of everything after the @ symbol.