### PR TITLE
paste-image-in-dialog

### DIFF
--- a/src/components/tweet-editor/tweet.tsx
+++ b/src/components/tweet-editor/tweet.tsx
@@ -646,6 +646,26 @@ export default function Tweet({ editMode = false, editTweetId }: TweetProps) {
     }
   }
 
+  const handlePaste = async (e: React.ClipboardEvent<HTMLDivElement>) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+
+    const files: File[] = []
+    
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      if (!item) continue
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
+        const file = item.getAsFile()
+        if (file) files.push(file)
+      }
+    }
+    if (files.length > 0) {
+      e.preventDefault()
+      await handleFiles(files)
+    }
+  }
+
   const removeMediaFile = (url: string) => {
     // Get and abort the single controller
     const controller = abortControllersRef.current.get(url)


### PR DESCRIPTION
#32 
Added feature to paste image directly to the input box from clipboard

https://github.com/user-attachments/assets/a3be6048-ac27-42e2-80e1-31b7de8433e4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pasting images directly into the tweet editor. Images pasted from the clipboard will now be detected and processed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->