### PR TITLE
Made the reference tweet section scrollable

### DIFF
--- a/src/app/studio/accounts/page.tsx
+++ b/src/app/studio/accounts/page.tsx
@@ -280,7 +280,7 @@ export default function AccountsPage() {
   })
 
   return (
-    <div className="relative z-10 max-w-2xl w-full mx-auto p-6 space-y-8">
+    <div className="relative z-10 max-w-2xl w-full mx-auto p-6 space-y-8 pb-32">
       <div className="space-y-2">
         <h1 className="text-2xl font-bold text-stone-900">Account Management</h1>
         <p className="text-stone-600">
@@ -609,7 +609,10 @@ export default function AccountsPage() {
                       {style.tweets.length} reference tweet
                       {style.tweets.length > 1 ? 's' : ''}
                     </p>
-                    <div className="space-y-3">
+                    <div
+                      className="space-y-3 border rounded-lg bg-stone-50 max-h-96 overflow-y-auto"
+                      style={{ minHeight: '6rem' }} // optional: ensures some height even if empty
+                    >
                       {style.tweets.map((tweet, index) => (
                         <div className="relative" key={index}>
                           <DuolingoButton


### PR DESCRIPTION
Wrapping the "Style Reference Tweets" section in a fixed-height, scrollable container. This prevents the page from growing indefinitely when many reference tweets are imported, allowing users to scroll through tweets within a visually contained area.

The right section of the video is the current application state, it is growing indefinitely if we add more tweets, the left side is the changes that I made.

https://github.com/user-attachments/assets/a1e055c0-23fc-4d49-b859-67fd82805f41



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased bottom padding on the Accounts page for improved spacing.
  * Enhanced the "Style Reference Tweets" section with a bordered, rounded container, light background, scrollable area, and minimum height for better visual presentation and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->