### PR TITLE
feat: option to let users re-fetch their profile

### DIFF
--- a/src/app/studio/accounts/page.tsx
+++ b/src/app/studio/accounts/page.tsx
@@ -43,6 +43,7 @@ import {
   Loader2,
   Lock,
   Plus,
+  RefreshCw,
   Save,
   Sparkles,
   Trash2,
@@ -215,6 +216,55 @@ export default function AccountsPage() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] })
+    },
+  })
+
+  const {
+    mutate: refreshProfilePicture,
+    isPending: isRefreshingProfile,
+    variables: refreshProfileVariables,
+  } = useMutation({
+    mutationFn: async ({ accountId }: { accountId: string }) => {
+      const res = await client.settings.refresh_profile_data.$post({ accountId })
+      return await res.json()
+    },
+    onMutate: async ({ accountId }) => {
+      // Cancel any outgoing refetches to avoid optimistic update being overwritten
+      await queryClient.cancelQueries({ queryKey: ['accounts'] })
+      await queryClient.cancelQueries({ queryKey: ['get-active-account'] })
+    },
+    onSuccess: ({ account, profile_image_url }, { accountId }) => {
+      queryClient.setQueryData(['accounts'], (oldData: any) => {
+        if (!oldData?.accounts) return oldData
+        return {
+          ...oldData,
+          accounts: oldData.accounts.map((acc: Account) =>
+            acc.id === accountId
+              ? { 
+                  ...acc, 
+                  profile_image_url, 
+                  name: account.name,
+                  username: account.username 
+                }
+              : acc
+          ),
+        }
+      })
+
+      const activeAccount = queryClient.getQueryData(['get-active-account']) as any
+      if (activeAccount?.id === accountId) {
+        queryClient.setQueryData(['get-active-account'], {
+          ...activeAccount,
+          profile_image_url,
+          name: account.name,
+          username: account.username,
+        })
+      }
+
+      toast.success('Profile refreshed!')
+    },
+    onError: (error: HTTPException) => {
+      toast.error(error.message || 'Failed to refresh profile picture')
     },
   })
 
@@ -429,6 +479,25 @@ export default function AccountsPage() {
                               <Check className="size-3 mr-1" />
                               Active
                             </DuolingoBadge>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <DuolingoButton
+                                  onClick={() => refreshProfilePicture({ accountId: acc.id })}
+                                  variant="secondary"
+                                  size="icon"
+                                  className="h-6 w-6 p-1"
+                                  loading={
+                                    isRefreshingProfile && 
+                                    refreshProfileVariables?.accountId === acc.id
+                                  }
+                                >
+                                  <RefreshCw className="size-3" />
+                                </DuolingoButton>
+                              </TooltipTrigger>
+                              <TooltipContent className="bg-gray-900 text-white border-gray-700">
+                                <p className="text-xs">Refresh profile data</p>
+                              </TooltipContent>
+                            </Tooltip>
                           </div>
                         </div>
                       ) : null}


### PR DESCRIPTION
fix : #24 

# Add Profile Data Refresh Feature for Connected Accounts

## Overview
Added a refresh button for active Twitter accounts to sync profile changes (avatar, name, username) from Twitter without requiring reconnection.

## Problem
Users frequently update their Twitter profile pictures, names, or usernames, but our app displayed stale cached data. Previously, users had to disconnect and reconnect accounts to see updates.

## Solution
- **Backend**: New `refresh_profile_data` endpoint that fetches fresh data from Twitter API using stored credentials
- **Frontend**: Small refresh button (🔄) next to "Active" badge with loading states and optimistic updates
- **State Management**: Targeted cache updates without unnecessary query invalidations

## What Gets Refreshed
✅ Profile picture (`profile_image_url`)  
✅ Display name (`name`)  
✅ Username/handle (`username`)

## Implementation Details
- Uses Twitter API v1.1 `currentUser()` method
- Updates both account cache and active account cache in Redis
- Optimistic UI updates with proper error handling
- Only available for active accounts to reduce API usage

## Testing
- ✅ Profile picture changes sync correctly
- ✅ Name changes update in real-time  
- ✅ Username changes reflect immediately
- ✅ Loading states and error handling work properly
- ✅ No unnecessary re-fetching of other data

## Files Changed
- `src/server/routers/settings-router.ts` - New refresh endpoint
- `src/app/studio/accounts/page.tsx` - UI and state management

## Demo

https://github.com/user-attachments/assets/f58af6fa-0534-4b9d-a99c-7c630e47862a

