### PR TITLE
Fix: Login issue

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,7 +20,7 @@ const getTrustedOrigins = () => {
   add(process.env.BETTER_AUTH_URL) // current deployment origin
   add(toOrigin(process.env.VERCEL_BRANCH_URL)) // preview branch URL (if any)
   add(toOrigin(process.env.VERCEL_URL)) // deployment URL
-  add('https://contentport.io') // prod
+  add('https://www.contentport.io') // prod
   add('http://localhost:3000') // local dev
   return Array.from(origins)
 }
@@ -30,7 +30,7 @@ export const auth = betterAuth({
   trustedOrigins: getTrustedOrigins(),
   plugins: [
     oAuthProxy({
-      productionURL: 'https://contentport.io',
+      productionURL: 'https://www.contentport.io',
       currentURL: process.env.BETTER_AUTH_URL,
     }),
   ],
@@ -74,7 +74,7 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID as string,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
-      redirectURI: 'https://contentport.io/api/auth/callback/google',
+      redirectURI: 'https://www.contentport.io/api/auth/callback/google',
     },
     twitter: {
       clientId: process.env.TWITTER_CLIENT_ID as string,


### PR DESCRIPTION
This pull request updates the authentication configuration to use the correct production domain for ContentPort. All references to the old production URL have been updated to include the `www` subdomain, ensuring consistency and proper routing for authentication flows.

**Authentication domain updates:**

* Changed the trusted production origin in `getTrustedOrigins` from `https://contentport.io` to `https://www.contentport.io`.
* Updated the `productionURL` for the OAuth proxy plugin to `https://www.contentport.io`.
* Modified the Google OAuth redirect URI to use `https://www.contentport.io/api/auth/callback/google`.

This fixes an issue where vercel forces the app to use www. on the url, and this returning an invalid origin.
