### PR TITLE
fix: make sure username and badge is inline

### DIFF
--- a/src/components/account-switcher.tsx
+++ b/src/components/account-switcher.tsx
@@ -94,7 +94,7 @@ export const AccountSwitcher = ({ showFullDetails }: AccountSwitcherProps) => {
                         {activeAccount.name}
                       </p>
                       {activeAccount.verified && (
-                        <Icons.verificationBadge className="size-3.5 shrink-0 flex-shrink-0" />
+                        <Icons.verificationBadge className="size-3.5 shrink-0" />
                       )}
                     </div>
                     <p className="text-xs font-normal text-muted-foreground">@{activeAccount.username}</p>


### PR DESCRIPTION
Makes sue the username and badge are rendered inline on the account-switcher component!

Before:

<img width="239" height="97" alt="image" src="https://github.com/user-attachments/assets/0bbdbe45-7511-4506-b1bf-f44490b4f2c3" />

After:

<img width="233" height="99" alt="image" src="https://github.com/user-attachments/assets/414913b7-6928-40a6-9dd8-4e88cf46e0fb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined account switcher styling with updated color scheme for improved visual hierarchy and readability.
  * Enhanced account details layout with clearer visual organization.
  * Improved active account selection indicator and list item appearance.
  * Updated tooltip styling for enhanced visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->