### PR TITLE
fix: prevent chat input from growing infinitely

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -261,7 +261,7 @@ const ChatInput = ({
                   <ContentEditable
                     autoFocus
                     disabled={isIndexing}
-                    className="w-full diabled:opacity-50 px-4 py-3 outline-none min-h-[4.5rem] text-base placeholder:text-gray-400"
+                    className="w-full diabled:opacity-50 px-4 py-3 outline-none min-h-[4.5rem] max-h-[50vh] overflow-y-auto text-base placeholder:text-gray-400"
                     style={{ minHeight: '4.5rem' }}
                     onPaste={handlePaste}
                   />

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -261,7 +261,7 @@ const ChatInput = ({
                   <ContentEditable
                     autoFocus
                     disabled={isIndexing}
-                    className="w-full diabled:opacity-50 px-4 py-3 outline-none min-h-[4.5rem] max-h-[50vh] overflow-y-auto text-base placeholder:text-gray-400"
+                    className="w-full disabled:opacity-50 px-4 py-3 outline-none min-h-[4.5rem] max-h-[50vh] overflow-y-auto text-base placeholder:text-gray-400"
                     style={{ minHeight: '4.5rem' }}
                     onPaste={handlePaste}
                   />


### PR DESCRIPTION
  ## Problem

  The chat input in the Assistant sidebar grows infinitely when users:
  - Press `Shift+Enter` to add multiple lines
  - Paste long text
  - Input grows upward, pushing messages until they disappear
  - Continues growing downward past the viewport
  - Attach/send buttons become hidden and inaccessible
  - Cursor at bottom of input becomes invisible
  
<img width="1461" height="988" alt="image" src="https://github.com/user-attachments/assets/addc0d31-dbe0-464b-829b-b00bce1bebb0" />

  Added `max-h-[50vh]` and `overflow-y-auto` to the `ContentEditable` component in the chat input.

  Now the input:
  - Grows naturally until it reaches 50% of viewport height
  - Becomes scrollable after reaching max height
  - Keeps attach/send buttons always visible
  
  
<img width="1461" height="988" alt="image" src="https://github.com/user-attachments/assets/bfb25083-ced8-47c3-a58b-9a80595a780c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chat input area now limits its height to half the viewport and enables vertical scrolling for longer messages, preventing the input from expanding excessively and keeping the layout tidy during extended conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->