### PR TITLE
docs: add Getting Started section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,44 @@
 # **contentport — public roadmap (last updated: 29th Nov 2025)**
 
+## Getting Started
+
+> **Note:** This is a WIP and not comprehensive. Please contribute an improvement if you want to help others getting started or us to offer a better onboarding experience.
+
+### Prerequisites
+
+- **`DATABASE_URL`** — A serverless Postgres database. This project uses Drizzle with the PostgreSQL dialect.
+  <a href="https://console.neon.tech/signup"><img src="https://img.shields.io/badge/Sign%20up-Neon%20Database-00e599?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyeiIvPjwvc3ZnPg==" alt="Sign up for Neon" /></a>
+
+  Or, if you prefer the CLI: `neonctl databases create --name contentport` ([Neon CLI docs](https://neon.com/docs/reference/cli-databases))
+
+### Follow along
+
+1. **Download the source code.** Clone the repo locally:
+   ```bash
+   gh repo clone joschan21/contentport
+   # or via HTTPS
+   git clone https://github.com/joschan21/contentport.git
+   ```
+2. **Configure secrets.** Set environment variables:
+   ```bash
+   cp .env.example .env
+   ```
+   Then fill in the keys obtained from [Prerequisites](#prerequisites) (at minimum `DATABASE_URL`).
+3. **Install dependencies:**
+   ```bash
+   bun i
+   ```
+4. **Push the database schema:**
+   ```bash
+   bun db:push
+   ```
+5. **Run the development server:**
+   ```bash
+   bun dev
+   ```
+
+---
+
 ## **Features in Pipeline**
 
 ### **Priority 1**

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ## Getting Started
 
-> **Note:** This is a WIP and not comprehensive. Please contribute an improvement if you want to help others getting started or us to offer a better onboarding experience.
+> **Note:** This is a WIP and not comprehensive. Please contribute an improvement if you want to help others get started or us to offer a better onboarding experience.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ---
 
-# **contentport — public roadmap (last updated: 29th Nov 2025)**
+# contentport
 
 ## Getting Started
 
@@ -47,6 +47,9 @@
   <a href="https://console.neon.tech/signup"><img src="https://img.shields.io/badge/Sign%20up-Neon%20Database-00e599?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyeiIvPjwvc3ZnPg==" alt="Sign up for Neon" /></a>
 
   Or, if you prefer the CLI: `neonctl databases create --name contentport` ([Neon CLI docs](https://neon.com/docs/reference/cli-databases))
+
+- **`NEXT_PUBLIC_POSTHOG_KEY`** — A PostHog project API key for analytics.
+  <a href="https://us.posthog.com/signup"><img src="https://img.shields.io/badge/Sign%20up-PostHog-1d4aff?style=for-the-badge&logo=posthog&logoColor=white" alt="Sign up for PostHog" /></a>
 
 ### Follow along
 
@@ -76,9 +79,11 @@
 
 ---
 
-## **Features in Pipeline**
+## **Public Roadmap** (last updated: 29th Nov 2025)
 
-### **Priority 1**
+### **Features in Pipeline**
+
+#### **Priority 1**
 
 * Dark mode (requested by many users)
 * Responsive layout (requested by many users)
@@ -108,7 +113,7 @@
 
 ---
 
-### **Priority 2**
+#### **Priority 2**
 
 * Switch between different LLMs — personal wish (Jo)
 * Personalized example ideas (similar to the OpenAI Atlas Browser) — requested by many
@@ -116,14 +121,14 @@
 
 ---
 
-### **Priority 3**
+#### **Priority 3**
 
 * Viral tweet library (potentially useful feature)
 * Enable web browsing (potentially useful feature)
 
 ---
 
-## **Bugs**
+### **Bugs**
 
 * Timezone issues / “-1 days” calendar error
 * Creating transcripts from videos
@@ -132,7 +137,7 @@
 
 ---
 
-## **Improvements**
+### **Improvements**
 
 * Assistant style handling
 * Upgrade modal / paywall / email flow

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
+<!-- PROJECT LOGO -->
+<p align="center">
+  <a href="https://github.com/contentport">
+   <img src="https://www.contentport.io/logo.png" alt="Contentport Logo" width="120">
+  </a>
+
+  <h3 align="center">Contentport</h3>
+
+  <p align="center">
+    Your content engine for growing on Twitter
+    <br />
+    <a href="https://www.contentport.io"><strong>Create and schedule Twitter content at scale »</strong></a>
+    <br />
+    <br />
+    <a href="https://www.contentport.io">Website</a>
+    ·
+    <a href="https://www.contentport.io/features">Features</a>
+    ·
+    <a href="https://github.com/contentport/issues">Issues</a>
+    ·
+    <a href="https://www.contentport.io/pricing">Pricing</a>
+  </p>
+</p>
+
+<p align="center">
+   <a href="https://www.contentport.io"><img src="https://img.shields.io/badge/Website-contentport.io-2ea44f" alt="Website"></a>
+   <a href="https://twitter.com/contentport"><img src="https://img.shields.io/badge/Twitter-@contentport-1DA1F2?logo=twitter" alt="Twitter"></a>
+   <a href="https://github.com/contentport"><img src="https://img.shields.io/badge/Open%20Source-100%25-brightgreen" alt="Open Source"></a>
+</p>
+
+<p align="center">
+   <a href="https://github.com/contentport/stargazers"><img src="https://img.shields.io/github/stars/contentport" alt="Github Stars"></a>
+   <a href="https://github.com/contentport/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="License"></a>
+</p>
+
+---
+
 # **contentport — public roadmap (last updated: 29th Nov 2025)**
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- Adds a **Getting Started** section to the README with prerequisites (Neon database setup with signup button + CLI) and step-by-step instructions (clone, configure `.env`, install, push schema, run dev server)
- Helps new contributors get up and running quicklier (sorry if my English is not englishing here).

## Why this changed
I wanted to get set up and running and followed the steps that I'm contributing here and saw the first error when running `bun i && bun dev` was about a missing `DATABASE_URL`.

## Out of scope
The real issue is that I was stuck with procuring the OAuth client secrets for social cross-posting. This is out of scope for this PR though, I shared some thoughts [on Twitter](https://x.com/richardpoelderl/status/2019377065557197054?s=20) with people that I had to think about but I'm not the right author for this discussion.

## Demo
### Header
<img width="1828" height="834" alt="Image" src="https://github.com/user-attachments/assets/6df500a9-6a02-4374-a173-bb2dd696d588" />

### Getting Started
<img width="1810" height="1448" alt="CleanShot 2026-02-05 at 13 31 39@2x" src="https://github.com/user-attachments/assets/839a165b-1923-4a95-9fa4-9d10e882d777" />

## Open questions
- [ 1️⃣ ](https://github.com/joschan21/contentport/pull/71/changes#r2768901664) Do you like the touch up on the readme in the commit? It's a taste matter I believe and you can omit [this commit](https://github.com/joschan21/contentport/pull/71/commits/e112bd5ff9ce12185203ba9da6b9d4b47bf1443b) in case you don't want it.
- [[ 2️⃣ ]](https://github.com/joschan21/contentport/pull/71/changes#r2768914703) Maybe you also want to be opinionated about the database provider. 
- [[ 3️⃣ ]](https://github.com/joschan21/contentport/pull/71#discussion_r2768896363)Could also use `env` variable checks to display a useful error message to users/agents when when  `DATABASE_URL` is missing (e.g. https://github.com/t3-oss/t3-env). Maybe the database setup instructions from the Prerequisites should be showed then, unsure.

## To test
- The neon CLI is untested

## Credits
Shoutout to the one and only @PeerRich for creating a polished and beautiful readme header for [calcom](https://github.com/calcom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
🦁 Initiated and editorially hand-crafted by [Richard in Berlin](https://github.com/p6l-richard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced README top with a full project landing: centered logo, title, branding links, and badges.
  * Expanded Getting Started with prerequisites, environment setup, concrete commands, and onboarding flow.
  * Reworked roadmap into a Public Roadmap and expanded Priority sections with many new feature ideas and UX notes.
  * Broadened Bugs & Improvements and examples with additional UI/UX and workflow details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->